### PR TITLE
Feature/add repositories controller

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class RepositoriesController < ApplicationController
+  def create
+    repository = Repository.new(repository_params)
+    if repository.save
+      SlackRepositoryInfo.create(repository_id: repository.id)
+      render json: repository.to_json
+    else
+      render json: { error: repository.errors }
+    end
+  end
+
+  private
+
+  def repository_params
+    params.require(:repository).permit(:project_id, :deploy_type, :supports_deploy, :name, :jira_project, :alias, :owner)
+  end
+end

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -4,7 +4,6 @@ class RepositoriesController < ApplicationController
   def create
     repository = Repository.new(repository_params)
     if repository.save
-      SlackRepositoryInfo.create(repository_id: repository.id)
       render json: repository.to_json
     else
       render json: { error: repository.errors }
@@ -14,6 +13,15 @@ class RepositoriesController < ApplicationController
   private
 
   def repository_params
-    params.require(:repository).permit(:project_id, :deploy_type, :supports_deploy, :name, :jira_project, :alias, :owner)
+    params.require(:repository).permit(
+      :project_id,
+      :deploy_type,
+      :supports_deploy,
+      :name,
+      :jira_project,
+      :alias,
+      :owner,
+      slack_repository_info_attributes: %i[deploy_channel dev_channel dev_group feed_channel]
+    )
   end
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -24,6 +24,8 @@ class Repository < ApplicationRecord
   has_many :branches
   has_many :applications
 
+  accepts_nested_attributes_for :slack_repository_info
+
   TAG_DEPLOY_TYPE = 'tag'
   BRANCH_DEPLOY_TYPE = 'branch'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   resources :applications, only: :show do
     resources :changelogs, only: :index
   end
+  resources :repositories, only: :create
 
   root 'application#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -56,6 +56,9 @@ ActiveRecord::Schema.define(version: 2021_03_31_214730) do
     t.index ["pull_request_id"], name: "index_commits_on_pull_request_id"
   end
 
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
   create_table "database_credentials", force: :cascade do |t|
     t.string "env"
     t.string "database_type"

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RepositoriesController, type: :controller do
+  let(:project) { FactoryBot.create(:project) }
+
+  describe '#create' do
+    it 'creates a repository' do
+      json = { repository: { project_id: project.id, name: 'testing' } }
+      expect { post :create, params: json }.to change { Repository.count }.by(1)
+    end
+
+    it 'creates a slack repository info' do
+      json = { repository: { project_id: project.id, name: 'testing', slack_repository_info_attributes: { deploy_channel: 'test' } } }
+      expect { post :create, params: json }.to change { SlackRepositoryInfo.count }.by(1)
+    end
+
+    it 'slack repository info has the correct attributes' do
+      json = { repository: { project_id: project.id, name: 'testing', slack_repository_info_attributes: { deploy_channel: 'test' } } }
+      post :create, params: json
+
+      expect(SlackRepositoryInfo.last).to have_attributes(deploy_channel: 'test')
+    end
+
+    it 'returns the repository data as JSON' do
+      json = { repository: { project_id: project.id, name: 'testing' } }
+      post :create, params: json
+
+      name = JSON.parse(response.body)['name']
+      expect(name).to eq('testing')
+    end
+
+    it 'returns a error message when fails to create' do
+      json = { repository: { name: 'testing' } }
+      post :create, params: json
+
+      error = JSON.parse(response.body)['error']
+      expect(error).to eq('project' => ['must exist'])
+    end
+  end
+end


### PR DESCRIPTION
If applied, this commit will ... [Add "repositories" controller, route and the corresponding specs. The "repositories" controller have only the create action, being able to create a new "repository" and a "slack repository info" simultaneously and sending a JSON with the "repository" data after that]

### Other minor changes:
 - minor change one
 - minor change two

### Card Link:
<MY_CARD_LINK>

### Design Expected Screenshot
<DESIGN_EXPECTED_SCREENSHOT>

### Implementation Screenshot or GIF
<MY_SCREENSHOT or MY_GIF>

### Notes:
[Add here any other information you believe reviewers need to be aware of]

