### PR TITLE
Azure Branch now return parsed commits

### DIFF
--- a/app/services/clients/azure/branch.rb
+++ b/app/services/clients/azure/branch.rb
@@ -6,7 +6,10 @@ module Clients
       def commits(repo, branch)
         url = "#{azure_url}git/repositories/#{repo}/commits?searchCriteria.itemVersion.version=#{branch}&api-version=4.1"
         response = Request.get(url, authorization)
-        response['value']
+        commits = response['value']
+        commits.map do |commit|
+          Clients::Azure::Parsers::CommitParser.new(commit)
+        end
       end
 
       def compare(repo, head, base)

--- a/app/services/clients/azure/release.rb
+++ b/app/services/clients/azure/release.rb
@@ -32,9 +32,9 @@ module Clients
         {
           name: tag_name,
           taggedObject: {
-            objectId: last_commit['commitId']
+            objectId: last_commit.sha
           },
-          message: last_commit['comment']
+          message: last_commit.message
         }
       end
     end


### PR DESCRIPTION
If applied, this commit will make Azure Branch return a list of parsed commits.

**Other minor changes:**
N/A

**Card Link:**
https://github.com/codelittinc/roadrunner/issues/237

**Design Expected Screenshot**
N/A

**Implementation Screenshot or GIF**
N/A

**Notes:**
N/A