### PR TITLE
Update hotfix_release_flow to use source_control_client instead of github client

### DIFF
--- a/app/services/flows/hotfix_release_flow.rb
+++ b/app/services/flows/hotfix_release_flow.rb
@@ -86,7 +86,7 @@ module Flows
     end
 
     def current_releases
-      @current_releases ||= Clients::Github::Release.new.list(repository.full_name)
+      @current_releases ||= source_control_client.new(repository).list_releases
     end
   end
 end


### PR DESCRIPTION
### Other minor changes:


### Card Link:
https://github.com/codelittinc/roadrunner/issues/269

### Notes:

