### PR TITLE
Update GithubWebhookParser destroy_branch! method params to get the pull_request repository name instead of full_name

### DIFF
--- a/app/services/parsers/github_webhook_parser.rb
+++ b/app/services/parsers/github_webhook_parser.rb
@@ -24,7 +24,7 @@ module Parsers
     end
 
     def destroy_branch!(pull_request)
-      Clients::Github::Branch.new.delete(pull_request.repository.full_name, pull_request.head)
+      Clients::Github::Branch.new.delete(pull_request.repository, pull_request.head)
     end
 
     def parse!


### PR DESCRIPTION
### Other minor changes:


### Card Link:
https://github.com/codelittinc/roadrunner/issues/282

### Notes:

